### PR TITLE
Fixed a crash when redmine "assign to group" is turned on

### DIFF
--- a/lib/auto_watch_hook.rb
+++ b/lib/auto_watch_hook.rb
@@ -5,7 +5,7 @@ class AutoWatchHook < Redmine::Hook::Listener
     unless @issue.watched_by?(User.current) || @issue.author == User.current
       @issue.add_watcher(User.current)
     end
-    unless @issue.assigned_to == nil || @issue.watched_by?(@issue.assigned_to) || @issue.author == @issue.assigned_to
+    unless @issue.assigned_to == nil || (not @issue.assigned_to === User) || @issue.watched_by?(@issue.assigned_to) || @issue.author == @issue.assigned_to
       @issue.add_watcher(@issue.assigned_to)
     end
   end


### PR DESCRIPTION
If an issue was assigned to a group, this plugin would attempt to add that group as a watcher.  Since that isn't a supported action, I added a clause to the conditional guard to prevent this.  That fixes the crash. 
